### PR TITLE
seperated out the stop service so it can be used in orchestration runner

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -150,8 +150,4 @@ debconf:
   pkg: 
     - installed
 
-mysql_stop: 
-  service: 
-    - name: mysql 
-    - dead
 

--- a/stop.sls
+++ b/stop.sls
@@ -1,0 +1,4 @@
+mysql_stop: 
+  service: 
+    - name: mysql 
+    - dead


### PR DESCRIPTION
This has been done so the salt formulas can be ran again. Previously there were several issues with stopping all the services at the same time. This PR prepares the formulas so the orchestration runner can stop the services consecutively instead of at the same time. 
MUST BE MERGED WITH: 
https://github.com/rcbops/RPC-Heat-Galera/pull/8
